### PR TITLE
chore: bump bpmn-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -801,15 +801,15 @@
       }
     },
     "bpmn-js": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-7.5.0.tgz",
-      "integrity": "sha512-0ANaE6Bikg1GmkcvO7RK0MQPX+EKYKBc+q7OWk39/16NcCdNZ/4UiRcCr9n0u1VUCIDsSU/jJ79TIZFnV5CNjw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-8.2.0.tgz",
+      "integrity": "sha512-ZfA5h0AtWkG9V3Sa8jg/0NDE6hPjewTm2r0EqFBg6nDFYBoq1kUnEiPO3Z+XyoMkPqTOREcZYetuboRgmZizTw==",
       "dev": true,
       "requires": {
         "bpmn-moddle": "^7.0.4",
         "css.escape": "^1.5.1",
-        "diagram-js": "^6.8.2",
-        "diagram-js-direct-editing": "^1.6.1",
+        "diagram-js": "^7.2.0",
+        "diagram-js-direct-editing": "^1.6.2",
         "ids": "^1.0.0",
         "inherits": "^2.0.4",
         "min-dash": "^3.5.2",
@@ -1619,36 +1619,36 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-6.8.2.tgz",
-      "integrity": "sha512-5EKYHjW2mmGsn9/jSenSkm8cScK5sO9eETBRQNIIzgZjxBDJn6eX964L2d7/vrAW9SeuijGUsztL9+NUinSsNg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.2.0.tgz",
+      "integrity": "sha512-K1cJkz/e00oX+wJqaAynonteRvDi/OHP+wgJS3+lulXMUc9vdk7o5m10Vdb60Mb/Z2bsbVRyn7pJmngj/jopEQ==",
       "dev": true,
       "requires": {
         "css.escape": "^1.5.1",
-        "didi": "^4.0.0",
+        "didi": "^5.2.1",
         "hammerjs": "^2.0.1",
-        "inherits": "^2.0.1",
-        "min-dash": "^3.5.0",
-        "min-dom": "^3.1.2",
+        "inherits": "^2.0.4",
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3",
         "object-refs": "^0.3.0",
         "path-intersection": "^2.2.0",
-        "tiny-svg": "^2.2.1"
+        "tiny-svg": "^2.2.2"
       }
     },
     "diagram-js-direct-editing": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.1.tgz",
-      "integrity": "sha512-FOW2qp7yT/L3Go/YfBOfnWrV2pc2PPoTSSRIg2nnld8pQDTnMaqKPva9GZEoCtcTJzPV4ctZX52ZdkJ3C7aWaA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.6.2.tgz",
+      "integrity": "sha512-hAiSnt6iETMLHBRsCU+XeATiV7u/rovlAX/l4MnvzW6+VeHqQOn+xFetD6JwxfTHKvT3h9fAQpfMZPOPlRFNlw==",
       "dev": true,
       "requires": {
-        "min-dash": "^3.0.0",
-        "min-dom": "^3.0.0"
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3"
       }
     },
     "didi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-4.0.0.tgz",
-      "integrity": "sha512-AzMElh8mCHOPWPCWfGjoJRla31fMXUT6+287W5ef3IPmtuBcyG9+MkFS7uPP6v3t2Cl086KwWfRB9mESa0OsHQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-5.2.1.tgz",
+      "integrity": "sha512-IKNnajUlD4lWMy/Q9Emkk7H1qnzREgY4UyE3IhmOi/9IKua0JYtYldk928bOdt1yNxN8EiOy1sqtSozEYsmjCg==",
       "dev": true
     },
     "diff": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/bpmn-io/bpmn-js-executable-fix#readme",
   "devDependencies": {
-    "bpmn-js": "^7.5.0",
+    "bpmn-js": "^8.2.0",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-plugin-bpmn-io": "^0.10.0",
@@ -41,6 +41,6 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "bpmn-js": "^6.x || ^7.x"
+    "bpmn-js": "^6.x || ^7.x || ^8.x"
   }
 }


### PR DESCRIPTION
Increase peer-dependency to bpmn-js@8 to avoid warnings via install.

Related to https://github.com/camunda/camunda-bpmn-js/issues/1